### PR TITLE
added an anchor tag to the cardActionArea component in the projectCard

### DIFF
--- a/Personal Portfolio/src/components/Home/ProjectCard.jsx
+++ b/Personal Portfolio/src/components/Home/ProjectCard.jsx
@@ -49,18 +49,25 @@ export default function ProjectCard({
             color: colorTheme.primaryText,
           }}
         >
-          <CardActionArea>
-            <CardMedia component="img" height="140" image={image} alt={title} />
-            <CardContent>
-              <h3 className="text-xl font-bold text-start mb-2">{title}</h3>
-              <p className="text-start text-md">{description}</p>
-            </CardContent>
-            <CardActions>
-              <Button size="small" href={link}>
-                View
-              </Button>
-            </CardActions>
-          </CardActionArea>
+          <a href={link} target="_blank">
+            <CardActionArea>
+              <CardMedia
+                component="img"
+                height="140"
+                image={image}
+                alt={title}
+              />
+              <CardContent>
+                <h3 className="text-xl font-bold text-start mb-2">{title}</h3>
+                <p className="text-start text-md">{description}</p>
+              </CardContent>
+              <CardActions>
+                <Button size="small" href={link}>
+                  View
+                </Button>
+              </CardActions>
+            </CardActionArea>
+          </a>
         </Card>
       </div>
       <CardActionArea>


### PR DESCRIPTION
Hi, I examined the personal-portfolio app and noticed that clicking the view button in the skills section reloads the entire page to display the project. To enhance the user experience, I added an anchor around the CardActionArea, so it now opens the project in a separate tab instead of reloading the whole page.






