### PR TITLE
Clarify search placeholder in Weight Converter

### DIFF
--- a/Weight-Converter/src/components/WeightConverter.jsx
+++ b/Weight-Converter/src/components/WeightConverter.jsx
@@ -237,7 +237,7 @@ export default function WeightConverter() {
                     onChange={(e) => setSearchTerm(e.target.value)}
                     placeholder="Search conversions (try: 100 kg)"
                     className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-300"
-                    aria-label="search history"
+                    aria-label="search conversions"
                   />
                   <AnimatePresence>
                     {suggestions.length > 0 && (

--- a/Weight-Converter/src/components/WeightConverter.jsx
+++ b/Weight-Converter/src/components/WeightConverter.jsx
@@ -235,7 +235,7 @@ export default function WeightConverter() {
                     type="search"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    placeholder="Search history (try: 100 kg)"
+                    placeholder="Search conversions (try: 100 kg)"
                     className="w-full px-4 py-2 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-300"
                     aria-label="search history"
                   />


### PR DESCRIPTION
Improved wording in the Weight Converter search input by changing the placeholder text from "Search history" to "Search conversions" for better clarity and consistency.